### PR TITLE
Fix similarity vector confusion

### DIFF
--- a/ping/analysis/partial_corr.py
+++ b/ping/analysis/partial_corr.py
@@ -27,8 +27,6 @@ Testing: Valentina Borghesani, valentinaborghesani@gmail.com
 import numpy as np
 from scipy import stats, linalg
 
-from statsmodels.regression.linear_model import OLS
-
 
 def partial_corr(C, verbose=0):
     """
@@ -64,8 +62,6 @@ def partial_corr(C, verbose=0):
             idx = np.ones(p, dtype=np.bool)
             idx[i] = False
             idx[j] = False
-            #beta_i = OLS(C[:, idx], C[:, j]).fit().params.squeeze()
-            #beta_j = OLS(C[:, idx], C[:, i]).fit().params.squeeze()
 
             beta_i = linalg.lstsq(C[:, idx], C[:, j])[0]
             beta_j = linalg.lstsq(C[:, idx], C[:, i])[0]

--- a/ping/analysis/similarity.py
+++ b/ping/analysis/similarity.py
@@ -57,7 +57,7 @@ def get_good_keys(all_data, filter_fn, sort_fn=sorted):
         return good_keys
 
 
-def build_similarity_matrix(all_data, good_keys=None, filter_fn=None,
+def build_similarity_vector(all_data, good_keys=None, filter_fn=None,
                             standardize=False, sort_fn=sorted,
                             metric='correlation'):
     """
@@ -97,14 +97,15 @@ def build_similarity_matrix(all_data, good_keys=None, filter_fn=None,
     return corr_mat, good_keys
 
 
-def compare_similarity_vectors(vec1, vec2, metric='correlation'):
+def compare_similarity_matrices(vec1, vec2, metric='correlation'):
 
     # Make sure both similarity matrices are in vector form.
     if metric == 'correlation':
-        if len(vec1.shape) == 2:
+        # Convert to vector form
+        if vec1.ndim == 2:
             vec1[np.eye(vec1.shape[0], dtype=bool)] = 0.
             vec1 = scipy.spatial.distance.squareform(vec1, 'tovector')
-        if len(vec2.shape) == 2:
+        if vec2.ndim == 2:
             vec2[np.eye(vec2.shape[0], dtype=bool)] = 0.
             vec2 = scipy.spatial.distance.squareform(vec2, 'tovector')
 
@@ -112,14 +113,15 @@ def compare_similarity_vectors(vec1, vec2, metric='correlation'):
         return scipy.stats.pearsonr(vec1, vec2)
 
     elif metric == 'norm-ish':
-        if len(vec1.shape) == 1:
+        # Convert to matrix form
+        if vec1.ndim == 1:
             vec1 = scipy.spatial.distance.squareform(vec1)
-        if len(vec2.shape) == 1:
+        if vec2.ndim == 1:
             vec2 = scipy.spatial.distance.squareform(vec2)
         return (np.trace(np.dot(vec1 - vec2, vec1 - vec2)), np.nan)
 
 
-def compute_similarity_matrices(data, filt_fns=None, **kwargs):
+def compute_similarity_vectors(data, filt_fns=None, **kwargs):
     if filt_fns is None:
         # Default filter: one group of everything!
         filt_fns = dict(all=lambda k: True)
@@ -129,18 +131,18 @@ def compute_similarity_matrices(data, filt_fns=None, **kwargs):
     for mat_type, filt_fn in filt_fns.items():
         print("Computing similarity matrix for %s" % (mat_type))
 
-        sim_mat, good_keys = build_similarity_matrix(data,
+        sim_mat, good_keys = build_similarity_vector(data,
                                                      filter_fn=filt_fn,
                                                      **kwargs)
         sim_dict[mat_type] = sim_mat
         sim_keys[mat_type] = good_keys
 
-    assert len(np.unique([len(vals) for vals in sim_dict.values()])) == 1 
+    assert len(np.unique([len(vals) for vals in sim_dict.values()])) == 1
 
     return sim_dict, sim_keys
 
 
-def compare_similarity_matrices(sim_dict):
+def compare_similarity_vectors(sim_dict):
     # 2. Compare similarity matrices.
     compare_keys = list(sim_dict.keys())
     n_keys = len(compare_keys)
@@ -150,8 +152,8 @@ def compare_similarity_matrices(sim_dict):
     for ki, key1 in enumerate(compare_keys):
         for kj in range(ki + 1, n_keys):
             key2 = compare_keys[kj]
-            r, pval = compare_similarity_vectors(sim_dict[key1],
-                                                 sim_dict[key2])
+            r, pval = compare_similarity_matrices(sim_dict[key1],
+                                                  sim_dict[key2])
             print("%s vs. %s: r**2=%.3f (p=%.3f)" % (
                 key1, key2, r**2, pval))
             mat_compare_mat[mat_idx] = r
@@ -166,13 +168,16 @@ def visualize_similarity_matrices(sim_dict, labels=None, class_labels=None, dyna
 
     for ki, key in enumerate(compare_keys):
         vmin, vmax = -1, 1
+        mat = sim_dict[key]
+        if mat.ndim == 1:
+            mat = scipy.spatial.distance.squareform(mat)
         if dynamic_color:
-            sim_dict[key][np.eye(sim_dict[key].shape[0], dtype=bool)] = 0.
-            vval = np.max(np.abs([sim_dict[key].min(), sim_dict[key].max()]))
+            mat[np.eye(mat.shape[0], dtype=bool)] = 0.
+            vval = np.max(np.abs([mat.min(), mat.max()]))
             vmin, vmax = np.asarray([-1, 1]) * vval
 
         ax = fh.add_subplot(1, n_keys, ki + 1)
-        plot_symmetric_matrix_as_triangle(sim_dict[key], ax=ax,
+        plot_symmetric_matrix_as_triangle(mat, ax=ax,
                                           vmin=vmin, vmax=vmax,
                                           labels=labels if ki == 0 else None,
                                           class_labels=class_labels if ki == 0 else None)

--- a/ping/analysis/similarity.py
+++ b/ping/analysis/similarity.py
@@ -1,7 +1,6 @@
 """
 Build similarity matrices for cortical area (left, right) and asymmetry
 """
-import copy
 from collections import OrderedDict
 
 import numpy as np

--- a/ping/utils/plotting.py
+++ b/ping/utils/plotting.py
@@ -28,7 +28,9 @@ def plot_normalized_hist(data, ax=None, **kwargs):
 
 
 def plot_symmetric_matrix_as_triangle(mat, ax=None, labels=None, class_labels=None, vmin=0, vmax=1):
-    """Plot symmetric matrix (like a covariance matrix) as a lower triangle."""
+    """Plot symmetric matrix (like a covariance matrix) as a lower triangle.
+
+    Can accept matrix in vector or matrix form."""
 
     # Scrub inputs
     if ax is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ requests
 scikit-learn
 scipy
 six
-# statsmodels

--- a/similarity.py
+++ b/similarity.py
@@ -9,8 +9,8 @@ from functools import partial
 import numpy as np
 from matplotlib import pyplot as plt
 
-from ping.analysis.similarity import (compare_similarity_matrices,
-                                      compute_similarity_matrices,
+from ping.analysis.similarity import (compare_similarity_vectors,
+                                      compute_similarity_vectors,
                                       visualize_similarity_matrices)
 from ping.data import (PINGData, which_hemi, get_nonhemi_key, is_nonimaging_key, 
                        get_anatomical_name, anatomical_sort,
@@ -67,10 +67,10 @@ else:
     p_data.filter(prefix_filter_fn)
 
     # Do the similarity computation; order by anatomy.
-    sim_dict, sim_keys = compute_similarity_matrices(p_data.data_dict,
-                                                     filt_fns=filt_fns,
-                                                     sort_fn=anatomical_sort,
-                                                     metric=metric)
+    sim_dict, sim_keys = compute_similarity_vectors(p_data.data_dict,
+                                                    filt_fns=filt_fns,
+                                                    sort_fn=anatomical_sort,
+                                                    metric=metric)
 
     # Split the keys into the class (the prefix)
     # an anatomical label from the rest of the key.
@@ -85,7 +85,7 @@ else:
         labels.append(get_anatomical_name(label))
 
     # Compare matrices (printed)
-    compare_similarity_matrices(sim_dict)
+    compare_similarity_vectors(sim_dict)
     
     #  Display the similarity matrices.
     ax = visualize_similarity_matrices(sim_dict, labels=labels,


### PR DESCRIPTION
The code did a poor job of distinguishing where similarity matrices were represented in (symmetric) matrix form vs. vector form.

This PR changes function names to make that clear, makes sure any function expecting matrix form can detect vector form and convert.

Without this PR, `similarity.py` was not running.