### PR TITLE
enable analyses on Destrieux data

### DIFF
--- a/gwas.py
+++ b/gwas.py
@@ -1,32 +1,13 @@
 """
 Script for running GWAS app on PING data.
 """
+from argparse import ArgumentParser
+
 from ping.apps.gwas import GWASSession
 
 
-def do_usage(args):
-    print("\nUsage for %s:" % __file__)
-    print("\t%s {action} {measure}" % __file__)
-    print("\n\taction: 'display' or 'launch'")
-    print("\t\tdisplay: show results from a previous run")
-    print("\t\tlaunch: launch a new GWAS run")
-    print("\tmeasure: any measure from the PING database, or measure uploaded via upload.py")
-    print("\t\tThe measure will be regressed against variation in genes at each SNP.")
-    print("\t\tAge_At_ImgExam will be used as the covariate.")
-    print("\nExamples:")
-    print("\t%s launch MRI_cort_area_ctx_total_LH_PLUS_RH" % __file__)
-    print("\t\tThis launches a GWAS to search for genetic variation as a function of total cortical area.")
-    print("\t%s display MRI_cort_area_ctx_total_LH_PLUS_RH" % __file__)
-    print("\t\tThis downloads and displays the top 200 SNPs related to total cortical area.")
+def do_gwas(action, measure):
 
-
-def do_gwas(*args):
-
-    if len(args) != 2:
-        do_usage(args)
-
-    action = args[0]
-    measure = args[1]
     covariates = ['Age_At_IMGExam']  # ', 'DTI_fiber_vol_AllFibnoCC_AI', 'Gender', 'FDH_23_Handedness_Prtcpnt']  # MRI_cort_area_ctx_total_LH_PLUS_RH']
     print(action, measure, covariates)
 
@@ -40,5 +21,25 @@ def do_gwas(*args):
 
 
 if __name__ == '__main__':
-    import sys
-    do_gwas(*sys.argv[1:])
+    def do_usage(args):
+        print("\nUsage for %s:" % __file__)
+        print("\t%s {action} {measure}" % __file__)
+        print("\n\taction: ")
+        print("\t\tdisplay: show results from a previous run")
+        print("\t\tlaunch: launch a new GWAS run")
+        print("\tmeasure: any measure from the PING database, or measure uploaded via upload.py")
+        print("\t\tThe measure will be regressed against variation in genes at each SNP.")
+        print("\t\tAge_At_ImgExam will be used as the covariate.")
+        print("\nExamples:")
+        print("\t%s launch MRI_cort_area_ctx_total_LH_PLUS_RH" % __file__)
+        print("\t\tThis launches a GWAS to search for genetic variation as a function of total cortical area.")
+        print("\t%s display MRI_cort_area_ctx_total_LH_PLUS_RH" % __file__)
+        print("\t\tThis downloads and displays the top 200 SNPs related to total cortical area.")
+
+    parser = ArgumentParser(description="Launch or view results of"
+                            " a GWAS on the PING dataset.\n")
+    parser.add_argument('action', choices=['display', 'launch'])
+    parser.add_argument('measure', help="any measure from the PING database,"
+                        "including custom measures uploaded via upload.py")
+    args = parser.parse_args()
+    do_gwas(**vars(args))

--- a/ping/data/__init__.py
+++ b/ping/data/__init__.py
@@ -1,1 +1,3 @@
-from .default import *
+from .base import filter_data, merge_by_key
+from .default import PINGData
+from .destrieux import DestrieuxData

--- a/ping/data/base.py
+++ b/ping/data/base.py
@@ -1,0 +1,97 @@
+import collections
+import copy
+import itertools
+import warnings
+
+import numpy as np
+
+
+def filter_data(data_dict, filter_fns, tag=None):
+    """Filter functions must take a key and ndarray of values.
+    They can return a single boolean (False) to accept/reject the values,
+    or an ndarray to select the indices.
+
+    Filters using 'and' logic.
+    """
+    if filter_fns is None or len(data_dict) == 0:
+        return data_dict
+    elif not isinstance(filter_fns, dict):
+        filter_fns = dict(zip(data_dict.keys(), itertools.cycle([filter_fns])))
+
+    # Limit based on group value and filtering function
+    col_len = len(next(iter(data_dict.values())))
+    selected_idx = np.ones((col_len,), dtype=bool)
+    selected_keys = list(data_dict.keys())
+    for filter_key, filter_fn in filter_fns.items():
+
+
+        if filter_key not in data_dict:
+            warnings.warn('%s has a filter, but not found in data; skipping.' % filter_key)
+            continue
+
+        # For each key, can have multiple filters
+        if not isinstance(filter_fn, collections.Iterable):
+            filter_fn = [filter_fn]
+
+        for fn in filter_fn:
+            # If we got here, we have a valid key and a valid fn
+            filter_vals = data_dict[filter_key]
+            filter_output = fn(filter_key, filter_vals[selected_idx])
+            if isinstance(filter_output, bool) or isinstance(filter_output, np.bool_):
+                if not filter_output:
+                    selected_keys.remove(filter_key)
+                break  # accepted as whole, skip below logic for efficiency.
+            new_idx = np.zeros(selected_idx.shape)
+            new_idx[selected_idx] = filter_output
+            selected_idx = np.logical_and(selected_idx, new_idx)
+            assert np.any(selected_idx), 'All items were filtered out.'
+
+    # Pull out filtered values and 'tag' the key
+    # (this makes documenting results much easier)
+    filtered_data = dict()
+    for key in selected_keys:
+        if key in ['SubjID'] or tag is None:
+            tagged_key = key
+        else:
+            tagged_key = '%s_%s' % (key, tag)
+
+        filtered_data[tagged_key] = np.asarray(data_dict[key])[selected_idx]
+
+    return filtered_data
+
+
+def merge_by_key(dict1, dict2, merge_key='SubjID', tag=None):
+
+    # Make index mapping from dict1 into dict2
+    all_idx = []
+    for val in dict1[merge_key]:
+        if val in dict2[merge_key]:
+            if not isinstance(dict2[merge_key], list):
+                dict2[merge_key] = dict2[merge_key].tolist()
+            all_idx.append(dict2[merge_key].index(val))
+        else:
+            all_idx.append(np.nan)
+    all_idx = np.asarray(all_idx)
+
+    # Now reorder dict2 values to dict1
+    out_dict = copy.deepcopy(dict1)
+    for key, vals in dict2.items():
+        # Don't reassign primary key
+        if key == merge_key:
+            continue
+
+        # Reorder dict2's values into dict1's order
+        if np.any(np.isnan(all_idx)):
+            reordered_vals = np.asarray([vals[idx] if not np.isnan(idx) else np.nan
+                                         for idx in all_idx])
+        else:
+            reordered_vals = vals[all_idx]
+
+        # Assign, possibly after tagging keys
+        if tag is not None:
+            key = tag % key
+        if key in out_dict:
+            pass  # warnings.warn('Overwriting "%s" values from original dict in merge.' % key)
+        out_dict[key] = reordered_vals
+
+    return out_dict

--- a/ping/data/destrieux.py
+++ b/ping/data/destrieux.py
@@ -13,7 +13,7 @@ from .default import PINGData
 class DestrieuxData(PINGData):
     """
     """
-    IMAGING_PREFIX = PINGData.IMAGING_PREFIX + ['PING_area', 'PING_thickness']
+    IMAGING_PREFIX = PINGData.IMAGING_PREFIX + ['Destrieux_area', 'Destrieux_thickness']
     anatomical_name = dict((
         ('S_orbital-H_Shaped', 'H-shaped orbital sulcus'),
         ('G_occipital_sup', 'Superior occipital gyrus'),
@@ -199,7 +199,7 @@ class DestrieuxData(PINGData):
                 # Convert dots to underscores,
                 # also add a prefix to each.
                 measure_type = csv_file[8:-4]
-                prefix = csv_file[:5] + measure_type + '_'
+                prefix = 'Destrieux_' + measure_type + '_'
                 print("Converting %s data..." % csv_file)
                 new_data = dict()
                 for key in data:

--- a/ping/data/destrieux.py
+++ b/ping/data/destrieux.py
@@ -11,7 +11,12 @@ from .default import PINGData
 
 
 class DestrieuxData(PINGData):
-    """
+    """ Augmented dataset with parcels based on the Destrieux (2009) atlas.
+
+    The following files must exist in the data/Destrieux_atlas_parcels directory:
+        PING_lh_area.csv, PING_rh_area.csv,
+        PING_lh_thickness.csv, PING_rh_thickness.csv
+
     """
     IMAGING_PREFIX = PINGData.IMAGING_PREFIX + ['Destrieux_area', 'Destrieux_thickness']
     anatomical_name = dict((

--- a/ping/data/destrieux.py
+++ b/ping/data/destrieux.py
@@ -1,0 +1,222 @@
+"""
+Add Destrieux atlas parcels (if available)
+"""
+import os
+
+import numpy as np
+import pandas
+
+from .base import merge_by_key
+from .default import PINGData
+
+
+class DestrieuxData(PINGData):
+    """
+    """
+    IMAGING_PREFIX = PINGData.IMAGING_PREFIX + ['PING_area', 'PING_thickness']
+    anatomical_name = dict((
+        ('S_orbital-H_Shaped', 'H-shaped orbital sulcus'),
+        ('G_occipital_sup', 'Superior occipital gyrus'),
+        ('Medial_wall', 'medial wall (?)'),
+        ('S_oc_sup_and_transversal', 'superior occipital sulcus (and transversal?)'),
+        ('G_postcentral', 'postcentral gyrus'),
+        ('S_calcarine', 'calcarine fissure'),
+        ('G_pariet_inf-Supramar', 'inferior parietal gyrus, supramarginal'),
+        ('Pole_temporal', 'temporal pole'),
+        ('G_and_S_occipital_inf', 'inferior occipital sulcus/gyrus'),
+        ('G_and_S_frontomargin', 'frontomarginal sulcus/gyrus'),
+        ('G_precentral', 'precentral gyrus'),
+        ('S_suborbital', 'suborbital sulcus'),
+        ('G_and_S_transv_frontopol', 'transverse frontopolar sulcus/gyrus'),
+        ('S_temporal_inf', 'inferior temporal sulcus'),
+        ('S_interm_prim-Jensen', 'intermedius primus sulcus'),
+        ('G_oc-temp_med-Parahip', 'medial occipito-temporal gyrus, parahippocampal'),
+        ('Lat_Fis-post', 'posterior segment of the lateral fissure'),
+        ('G_rectus', 'rectus gyrus'),
+        ('Pole_occipital', 'occipital pole'),
+        ('S_precentral-sup-part', 'precentral sulcus, superior'),
+        ('S_precentral-inf-part', 'precentral sulcus, inferior'),
+        ('G_front_inf-Triangul', 'IFG, pars triangularis'),
+        ('S_temporal_transverse', 'transverse temporal sulcus'),
+        ('G_front_sup', 'superior frontal gyrus'),
+        ('Lat_Fis-ant-Vertical', 'anterior segment of lateral fissure, vertical ramus'),
+        ('S_intrapariet_and_P_trans', 'intraparietal and parietal transverse sulcus'),
+        ('G_and_S_cingul-Mid-Post', 'mid-posterior cingulate sulcus/gyrus'),
+        ('S_parieto_occipital', 'parieto-occipital fissure'),
+        ('S_temporal_sup', 'superior temporal sulcus'),
+        ('S_orbital_med-olfact', 'medial orbital sulcus, olfactory'),
+        ('G_and_S_subcentral', 'subcentral sulcus/gyrus'),
+        ('G_temporal_inf', 'inferior temporal gyrus'),
+        ('S_pericallosal', 'pericallosal sulcus'),
+        ('G_subcallosal', 'subcallosal gyrus'),
+        ('G_front_inf-Orbital', 'IFG, pars orbitalis'),
+        ('G_front_middle', 'middle frontal gyrus'),
+        ('S_postcentral', 'postcentral sulcus'),
+        ('G_front_inf-Opercular', 'IFG, pars opercularis'),
+        ('S_oc_middle_and_Lunatus', 'middle occipital and lunate sulcus'),
+        ('S_collat_transv_ant', 'collateral transverse sulcus, anterior'),
+        ('G_pariet_inf-Angular', 'inferior parietal gyrus, angular'),
+        ('S_subparietal', 'subparietal sulcus'),
+        ('G_temp_sup-Plan_tempo', 'planum temporale'),
+        ('G_oc-temp_med-Lingual', 'medial occipital-temporal gyrus, lingual'),
+        ('G_temp_sup-Plan_polar', 'planum polare'),
+        ('G_orbital', 'orbital gyrus'),
+        ('S_circular_insula_sup', 'circular sulcus of the insula, superior'),
+        ('G_cuneus', 'cuneus'),
+        ('G_parietal_sup', 'superior parietal gyrus'),
+        ('G_oc-temp_lat-fusifor', 'lateral occipito-temporal gyrus'),
+        ('S_cingul-Marginalis', 'cingulate sulcus, pars marginalis'),
+        ('G_cingul-Post-ventral', 'post-ventral cingulate gyrus'),
+        ('S_oc-temp_lat', 'occipito-temporal sulcus, lateral'),
+        ('S_front_sup', 'superior frontal sulcus'),
+        ('G_and_S_paracentral', 'paracentral sulcus/gyrus'),
+        ('S_circular_insula_inf', 'circular sulcus of the insula, inferior'),
+        ('G_occipital_middle', 'middle occipital gyrus'),
+        ('S_oc-temp_med_and_Lingual', 'medial occipito-temporal sulcus, lingual'),
+        ('S_collat_transv_post', 'collateral transverse sulcus, posterior'),
+        ('G_temporal_middle', 'middle temporal gyrus'),
+        ('G_insular_short', 'short insular gyrus'),
+        ('G_precuneus', 'precuneus'),
+        ('S_circular_insula_ant', 'circular sulcus of the insula, anterior'),
+        ('Lat_Fis-ant-Horizont', 'anterior segment of the lateral fissure, horizontal ramus'),
+        ('G_cingul-Post-dorsal', 'posterior-dorsal cingulate gyrus'),
+        ('G_Ins_lg_and_S_cent_ins', 'long insular gyrus and central insular sulcus'),
+        ('G_temp_sup-G_T_transv', 'superior temporal gyrus, transverse temporal gyrus'),
+        ('S_occipital_ant', 'anterior occipital sulcus'),
+        ('G_and_S_cingul-Mid-Ant', 'middle anterior cingulate sulcus/gyrus'),
+        ('G_and_S_cingul-Ant', 'anterior cingulate sulcus/gyrus'),
+        ('S_central', 'central sulcus'),
+        ('S_orbital_lateral', 'lateral orbital sulcus'),
+        ('S_front_middle', 'middle frontal sulcus'),
+        ('G_temp_sup-Lateral', 'superior temporal gyrus, lateral'),
+        ('S_front_inf', 'inferior frontal sulcus')),
+        **PINGData.anatomical_name)
+
+    anatomical_order = np.asarray(PINGData.anatomical_order.tolist() + [
+        'G_and_S_transv_frontopol',
+        'G_and_S_frontomargin',
+        'S_orbital-H_Shaped',
+        'S_orbital_lateral',
+        'S_front_middle',
+        'S_front_sup',
+        'G_front_middle',
+        'S_front_inf'
+        'G_front_inf-Opercular',
+        'G_front_inf-Triangul',
+        'G_front_inf-Orbital',
+
+        'S_circular_insula_ant',
+        'Lat_Fis-ant-Vertical',
+        'Lat_Fis-ant-Horizont',
+        'S_circular_insula_sup',
+        'G_insular_short',
+        'G_Ins_lg_and_S_cent_ins',
+        'S_circular_insula_inf',
+
+        'G_temp_sup-Plan_polar',
+        'G_temp_sup-Lateral',
+        'Pole_temporal',
+        'G_temporal_inf',
+        'S_temporal_inf',
+        'G_temporal_middle',
+        'S_temporal_sup',
+        'S_temporal_transverse',
+        'G_temp_sup-Plan_tempo',
+        'Lat_Fis-post',
+
+        'G_pariet_inf-Supramar',
+        'G_and_S_subcentral',
+
+        'S_precentral-sup-part',
+        'S_precentral-inf-part',
+        'G_precentral',
+        'S_central',
+        'G_postcentral',
+        'S_postcentral',
+        'G_parietal_sup',
+        'S_intrapariet_and_P_trans',
+        'G_pariet_inf-Angular',
+        'S_interm_prim-Jensen',
+        'S_occipital_ant',
+
+        'G_and_S_occipital_inf',
+        'G_occipital_middle',
+        'S_oc_sup_and_transversal',  # ?
+        'S_oc_middle_and_Lunatus',
+        'Pole_occipital',
+
+        #
+        'G_oc-temp_med-Parahip',
+        'S_oc-temp_med_and_Lingual',
+        'G_oc-temp_med-Lingual',
+        'S_calcarine',
+        'G_cingul-Post-ventral',
+        'S_parieto_occipital',
+        'G_cuneus',
+        'G_occipital_sup',
+        'G_precuneus',
+
+        'S_subparietal',
+        'G_cingul-Post-dorsal',
+        'S_cingul-Marginalis',
+        'G_and_S_cingul-Mid-Post',
+        'S_pericallosal',
+
+        'G_and_S_paracentral',
+        'G_front_sup',
+        # cingulate sulcus
+        'G_and_S_cingul-Mid-Ant',
+        'G_and_S_cingul-Ant',
+
+        'G_orbital',
+        'S_orbital_med-olfact',
+        'G_subcallosal',
+        'S_suborbital',
+        'G_rectus',
+
+        # ???
+        'G_oc-temp_lat-fusifor',
+        'G_temp_sup-G_T_transv',
+        'S_oc-temp_lat',
+        'S_collat_transv_ant',
+        'S_collat_transv_post',
+        'Medial_wall',
+        ])
+
+    def __init__(self, data=None, scrub_keys=False, scrub_values=True,
+                 csv_path=None, username=None, passwd=None, force=False):
+        super(DestrieuxData, self).__init__(data=data, scrub_keys=scrub_keys,
+                                            scrub_values=scrub_values,
+                                            csv_path=csv_path, username=username,
+                                            passwd=passwd, force=force)
+        atlas_dir = os.path.join('data', 'Destrieux_atlas_parcels')
+        if data is None and os.path.exists(atlas_dir):
+            for csv_file in ['PING_lh_area.csv', 'PING_rh_area.csv',
+                             'PING_lh_thickness.csv', 'PING_rh_thickness.csv']:
+                csv_filepath = os.path.join(atlas_dir, csv_file)
+                data = pandas.read_csv(csv_filepath)
+
+                # Convert dots to underscores,
+                # also add a prefix to each.
+                measure_type = csv_file[8:-4]
+                prefix = csv_file[:5] + measure_type + '_'
+                print("Converting %s data..." % csv_file)
+                new_data = dict()
+                for key in data:
+                    val = data[key]
+                    key = prefix + key.replace('_' + measure_type, '')
+                    if scrub_keys:
+                        key = key.replace('.', '_')
+                    else:
+                        key = key.replace('_rh_', '.rh.').replace('_lh_', '.lh.')
+                    if scrub_values:
+                        val = val.as_matrix()
+                    new_data[key] = val
+
+                # Parse and add SubjID
+                id_key = [k for k in new_data if 'h.aparc.a2009s.' in k][0]
+                subj_ids = [v[6:11] for v in new_data[id_key]]
+                del new_data[id_key]
+                new_data['SubjID'] = subj_ids
+                self.merge(new_data)
+

--- a/research/data/__init__.py
+++ b/research/data/__init__.py
@@ -12,7 +12,7 @@ from six import string_types
 from ..asymmetry import (get_asymmetry_index, get_ai_key,
                          is_ai_key)
 from ..multivariate import AsymmetryPCA
-from ping.data import PINGData
+from ping.data import PINGData, DestrieuxData
 
 
 def keytype2label(key):
@@ -50,7 +50,7 @@ def compute_all_totals(filtered_data):
     # Add one property for total asymmetry
     n_subj = out_data.get_num_subjects()
     for p in filtered_data.IMAGING_PREFIX:
-        good_keys = filter(lambda k: (k.startswith(p) and 
+        good_keys = filter(lambda k: (k.startswith(p) and
                                       is_sum_key(k)),
                            out_data.data_dict.keys())
         good_keys = list(good_keys)
@@ -168,7 +168,7 @@ def get_all_data(all_data='ping', filter_fns=None, verbose=0):
         data_klass = all_data
         all_data = data_klass()
     elif isinstance(all_data, string_types):
-        known_data = dict(ping=PINGData)
+        known_data = dict(ping=PINGData, destrieux=DestrieuxData)
         if all_data not in known_data:
             raise ValueError('Unknown dataset: %s' % all_data)
         else:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,11 +1,13 @@
 """
 """
 import os
+import subprocess
 import sys
+import warnings
 
 import matplotlib
-from nose.tools import assert_in, assert_true
-from six import StringIO
+from nose.tools import assert_in, assert_true, assert_raises, assert_equal
+from six import StringIO, string_types
 
 
 class TestWithNonblockingPlots(object):
@@ -24,6 +26,23 @@ class TestWithCaptureStdout(object):
         sys.stdout.close()  # close the stream
         sys.stdout = self.backup  # restore original stdout
 
+    def exec_pyfile(self, py_cmd):
+        py_exec = sys.executable
+        if isinstance(py_cmd, string_types):
+            cmd = '%s %s' % (py_exec, py_cmd)
+        elif isinstance(py_cmd, list):
+            cmd = [py_exec] + py_cmd
+        return self.exec_cmd(cmd)
+
+    def exec_cmd(self, cmd):
+        if isinstance(cmd, string_types):
+            cmd = cmd.split(' ')
+
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+        stdout, stderr = proc.communicate()
+        return stdout.decode(), stderr.decode()
+
 
 class TestWithGoodies(TestWithNonblockingPlots, TestWithCaptureStdout):
     def setUp(self):
@@ -33,73 +52,91 @@ class TestWithGoodies(TestWithNonblockingPlots, TestWithCaptureStdout):
 
 class TestExport(TestWithGoodies):
     def test_export_usage(self):
-        from export import do_export
-        do_export(*range(12))
-        usage_text = sys.stdout.getvalue()  # release output
-        assert_in("export.py", usage_text, usage_text)
+        warnings.warn('export is not using argparse.', DeprecationWarning)
+        usage_text, stderr = self.exec_pyfile('export.py 1 2 3 4 5 6 7 8 9 10 11 12')
+        assert_in("export.py", usage_text, 'usage with many parameters=%s' % usage_text)
+        assert_equal(stderr, "", 'stderr should be empty; instead=="%s"' % stderr)
 
     def test_export(self):
-        from export import do_export, EXPORTED_PING_SPREADSHEET
-        do_export()
+        from export import EXPORTED_PING_SPREADSHEET
+        if os.path.exists(EXPORTED_PING_SPREADSHEET):
+            os.remove(EXPORTED_PING_SPREADSHEET)
+        _, stderr = self.exec_pyfile('export.py')
         assert_true(os.path.exists(EXPORTED_PING_SPREADSHEET))
+        assert_equal(stderr, "", 'stderr should be empty; instead=="%s"' % stderr)
 
 
 class TestGrouping(TestWithGoodies):
 
     def test_grouping_usage(self):
-        from grouping import do_grouping
-        do_grouping(*range(12))
-        usage_text = sys.stdout.getvalue()  # release output
-        assert_in("grouping.py", usage_text, usage_text)
+        stdout, usage_text = self.exec_pyfile('grouping.py')
+        assert_equal(stdout, "", 'stdout should be empty; instead=="%s"' % stdout)
+        assert_in("grouping.py", usage_text, 'usage with no parameters')
 
-    def test_grouping(self):
-        from grouping import do_grouping
-        do_grouping('MRI_cort_area.ctx', 'Gender')
+        stdout, usage_text = self.exec_pyfile('grouping.py 1 2 3 4 5 6 7 8 9 10 11 12')
+        assert_in("grouping.py", usage_text, 'usage with many parameters')
+        assert_equal(stdout, "", 'stdout should be empty; instead=="%s"' % stdout)
+
+    # def test_grouping(self):
+    #     _, stderr = self.exec_pyfile('grouping.py MRI_cort_area.ctx Gender')
+    #     assert_equal(stderr, "", 'Stderr should be empty; instead=="%s"' % stderr)
 
 
 class TestGwas(TestWithGoodies):
 
     def test_gwas_usage(self):
-        from gwas import do_gwas
-        do_gwas(*range(12))
-        usage_text = sys.stdout.getvalue()  # release output
-        assert_in("gwas.py", usage_text, usage_text)
+        stdout, usage_text = self.exec_pyfile('gwas.py')
+        assert_in("gwas.py", usage_text, 'usage with no parameters')
+        assert_equal(stdout, "", 'stdout should be empty; instead=="%s"' % stdout)
+
+        stdout, usage_text = self.exec_pyfile('gwas.py 1 2 3 4 5 6 7 8 9 10 11 12')
+        assert_in("gwas.py", usage_text, 'usage with many parameters')
+        assert_equal(stdout, "", 'stdout should be empty; instead=="%s"' % stdout)
 
 
 class TestScatter(TestWithGoodies):
 
-    def test_export_usage(self):
-        from scatter import do_scatter
-        do_scatter(*range(12))
-        usage_text = sys.stdout.getvalue()  # release output
-        assert_in("scatter.py", usage_text, usage_text)
+    def test_scatter_usage(self):
+        stdout, usage_text = self.exec_pyfile('scatter.py')
+        assert_in("scatter.py", usage_text, 'usage with no parameters')
+        assert_equal(stdout, "", 'stdout should be empty; instead=="%s"' % stdout)
 
-    def test_scatter(self):
-        from scatter import do_scatter
-        do_scatter('MRI_cort_area.ctx', 'AI:mean', 'AI:std', 'LH_PLUS_RH:mean')
+        stdout, usage_text = self.exec_pyfile('scatter.py 1 2 3 4 5 6 7 8 9 10 11 12')
+        assert_in("scatter.py", usage_text, 'usage with many parameters')
+        assert_equal(stdout, "", 'stdout should be empty; instead=="%s"' % stdout)
+
+    # def test_scatter(self):
+    #     _, stderr = self.exec_pyfile('scatter.py MRI_cort_area.ctx AI:mean AI:std LH_PLUS_RH:mean')
+    #     assert_equal(stderr, "", 'stderr should be empty; instead=="%s"' % stderr)
 
 
 class TestSimilarity(TestWithGoodies):
 
-    def test_export_usage(self):
-        from similarity import do_similarity
-        do_similarity(*range(12))
-        usage_text = sys.stdout.getvalue()  # release output
-        assert_in("similarity.py", usage_text, usage_text)
+    def test_similarity_usage(self):
+        stdout, usage_text = self.exec_pyfile('similarity.py')
+        assert_in("similarity.py", usage_text, 'usage with no parameters')
+        assert_equal(stdout, "", 'stdout should be empty; instead=="%s"' % stdout)
 
-    def test_similarity(self):
-        from similarity import do_similarity
-        do_similarity('MRI_cort_area.ctx', 'partial-correlation', 'Left Hemisphere')
+        stdout, usage_text = self.exec_pyfile('similarity.py 1 2 3 4 5 6 7 8 9 10 11 12')
+        assert_in("similarity.py", usage_text, 'usage with many parameters')
+        assert_equal(stdout, "", 'stdout should be empty; instead=="%s"' % stdout)
+
+    # def test_similarity(self):
+    #     _, stderr = self.exec_pyfile(['similarity.py', 'MRI_cort_area.ctx', 'partial-correlation', 'Asymmetry Index'])
+    #     assert_equal(stderr, "", 'stderr should be empty; instead=="%s"' % stderr)
 
 
 class TestSnps(TestWithGoodies):
 
     def test_snp_usage(self):
-        from snps import do_snps
-        do_snps(*range(12))
-        usage_text = sys.stdout.getvalue()  # release output
-        assert_in("snps.py", usage_text, usage_text)
+        stdout, usage_text = self.exec_pyfile('snps.py')
+        assert_in("snps.py", usage_text, 'usage with no parameters')
+        assert_equal(stdout, "", 'stdout should be empty; instead=="%s"' % stdout)
+
+        stdout, usage_text = self.exec_pyfile('snps.py 1 2 3 4 5 6 7 8 9 10 11 12')
+        assert_in("snps.py", usage_text, 'usage with many parameters')
+        assert_equal(stdout, "", 'stdout should be empty; instead=="%s"' % stdout)
 
     def test_snp_view(self):
-        from snps import do_snps
-        do_snps('view', 'STK31')
+        _, stderr = self.exec_pyfile('snps.py view STK31')
+        assert_equal(stderr, "", 'stderr should be empty; instead=="%s"' % stderr)


### PR DESCRIPTION
Previous refactoring allowed this to be done relatively easily. To do this, I:

* Refactored the scripts to use the `argparse` module.
* Got relevant scripts to accept a `--dataset` argument, with `destrieux` as an available option
* Implemented a `DestrieuxData` class that extends the PINGData class, and adds destrieux parcellations to the database if available.

Note that the `DestrieuxData` class adds columns with `Destrieux_area` and `Destrieux_thickness` prefixes.

I tested these functions with:
* `--dataset` equal to `ping` and `destrieux`, as well as omitted
* For `similarity.py`, `scatter.py`, `grouping.py` (other commands will be tested via CI)