### PR TITLE
Allow specifying username from the command-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,7 @@ Installation steps:
 4. Visit https://ping-dataportal.ucsd.edu/applications/User/requestLogin.php and request access to the PING data portal.
 
 
-# Usage
-
-Scripts can be modified to accept your username and password, or can be run as-is if you set the following environment variables:
-
-* `PING_USERNAME` - your PING data portal username (*not* your email address).
-* `PING_PASSWORD` - your PING data portal password
+# Scripts
 
 The following functions of the data portal are available through this scripting interface:
 
@@ -34,7 +29,22 @@ The following functions of the data portal are available through this scripting 
 * `snps.py` - Script interface for the SNP browser; find genes associated with SNPs, SNPs associated with genes, and download user data for specific genes. **NOTE: PING limits SNP downloads to 5000, so use them wisely!**
 * `upload.py` - Upload your local CSV with derived measures to the PING data portal, so you can access in the Data browser.
 
-## Examples
+### Authenticating in scripts
+
+Scripts must be run with a valid username and password to the PING portal--if you don't have one, you'll need to [request one](https://ping-dataportal.ucsd.edu/applications/User/requestLogin.php).
+
+There are two ways to pass your username and password to the scripts:
+
+* Via the command-line: use parameters `--username=[USERNAME] --password=[PASSWORD]`
+* Via the shell: set the following environment variables:
+    * `PING_USERNAME` - your PING data portal username (*not* your email address).
+    * `PING_PASSWORD` - your PING data portal password
+
+
+### Example script usage
+
+These examples assume that you've set your username and password via shell environment variables. If you haven't, you'll need to add the `--username=[USERNAME]` and `--password=[PASSWORD]` options to the commands below.
+
 * `python export.py` - exports data sheet, including computed measures, to a local CSV file. 
 * `python grouping.py MRI_cort_area.ctx Gender` - show linear regression for each cortical area measure, with regression by gender overlaid on the same plot.
 * `python scatter.py MRI_cort_area AI:mean AI:std LH_PLUS_RH:mean` - show a scatter plot over cortical area measures, of asymmetry index mean vs. standard deviation, with dot size given by the total area (LH+RH) 

--- a/export.py
+++ b/export.py
@@ -4,6 +4,7 @@ Export derived measures spreadsheet
 """
 import sys
 
+from ping.apps import PINGSession
 from research.grouping import (do_usage_grouping, group_and_execute,
                                parse_filter_args)
 

--- a/grouping.py
+++ b/grouping.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import scipy.stats
 
+from ping.apps import PINGSession
 from ping.utils import do_and_plot_regression
 from ping.utils.plotting import (plot_symmetric_matrix_as_triangle,
                                  equalize_xlims, equalize_ylims,
@@ -240,9 +241,11 @@ def loop_show_asymmetry(prefix,
                         grouping_keys=['Gender', 'FDH_23_Handedness_Prtcpnt'],
                         xaxis_key='Age_At_IMGExam',
                         plots='regressions',
-                        dataset='ping'):
+                        dataset='ping',
+                        username=None,
+                        passwd=None):
     """ Loop over all properties to show asymmetry."""
-    data = get_all_data(dataset)
+    data = get_all_data(dataset, username=username, passwd=passwd)
     data.filter(lambda k, v: 'fuzzy' not in k)  # Remove 'fuzzy'
     data.filter([partial(lambda k, v, p: (k.startswith(p) or
                                           k in grouping_keys or
@@ -281,7 +284,8 @@ def loop_show_asymmetry(prefix,
 
 
 def do_grouping(prefix, grouping_keys, xaxis_key='Age_At_IMGExam',
-                plots='regressions', dataset='ping'):
+                plots='regressions',
+                dataset='ping', username=None, passwd=None):
     prefix = prefix.split(',')
     grouping_keys = grouping_keys.split(',')
     plots = plots.split(',')
@@ -290,7 +294,9 @@ def do_grouping(prefix, grouping_keys, xaxis_key='Age_At_IMGExam',
                         grouping_keys=grouping_keys,
                         xaxis_key=xaxis_key,
                         plots=plots,
-                        dataset=dataset)
+                        dataset=dataset,
+                        username=username,
+                        passwd=passwd)
 
 
 if __name__ == '__main__':
@@ -326,5 +332,10 @@ if __name__ == '__main__':
                         help="comma-separated list of plots")
     parser.add_argument('--dataset', choices=['ping', 'destrieux'],
                         nargs='?', default='ping')
+    parser.add_argument('--username', nargs='?',
+                        default=PINGSession.env_username())
+    parser.add_argument('--password', nargs='?',
+                        default=PINGSession.env_passwd(),
+                        dest='passwd')
     args = parser.parse_args()
     do_grouping(**vars(args))

--- a/gwas.py
+++ b/gwas.py
@@ -1,17 +1,18 @@
 """
 Script for running GWAS app on PING data.
 """
+import os
 from argparse import ArgumentParser
 
 from ping.apps.gwas import GWASSession
 
 
-def do_gwas(action, measure):
+def do_gwas(action, measure, username=None, passwd=None):
 
     covariates = ['Age_At_IMGExam']  # ', 'DTI_fiber_vol_AllFibnoCC_AI', 'Gender', 'FDH_23_Handedness_Prtcpnt']  # MRI_cort_area_ctx_total_LH_PLUS_RH']
     print(action, measure, covariates)
 
-    sess = GWASSession()  # username/password stored in an env variable for me.
+    sess = GWASSession(username=username, passwd=passwd)
     sess.login()
 
     if action == 'display':
@@ -41,5 +42,10 @@ if __name__ == '__main__':
     parser.add_argument('action', choices=['display', 'launch'])
     parser.add_argument('measure', help="any measure from the PING database,"
                         "including custom measures uploaded via upload.py")
+    parser.add_argument('--username', nargs='?',
+                        default=GWASSession.env_username())
+    parser.add_argument('--password', nargs='?',
+                        default=GWASSession.env_passwd(),
+                        dest='passwd')
     args = parser.parse_args()
     do_gwas(**vars(args))

--- a/ping/apps/__init__.py
+++ b/ping/apps/__init__.py
@@ -15,18 +15,24 @@ class PINGSession(object):
     """
     """
     project_name = 'PING'
-    ENV_USERNAME = 'PING_USERNAME'
-    ENV_PASSWORD = 'PING_PASSWORD'
     base_url = 'https://ping-dataportal.ucsd.edu/'
 
     def __init__(self, username=None, passwd=None, verbose=1):
-        self.username = username or os.environ.get(self.ENV_USERNAME)
-        self.passwd = passwd or os.environ.get(self.ENV_PASSWORD)
+        self.username = username or self.env_username()
+        self.passwd = passwd or self.env_passwd()
         self.check_login_info()
 
         self.sess = requests.Session()
         self.result_ids = None  # current dictionary of result IDs
         self.verbose = verbose  # level of output
+
+    @classmethod
+    def env_username(klass):
+        return os.environ.get('PING_USERNAME')
+
+    @classmethod
+    def env_passwd(klass):
+        return os.environ.get('PING_PASSWORD')
 
     def check_login_info(self):
         if self.username is None:

--- a/ping/apps/__init__.py
+++ b/ping/apps/__init__.py
@@ -15,11 +15,13 @@ class PINGSession(object):
     """
     """
     project_name = 'PING'
+    ENV_USERNAME = 'PING_USERNAME'
+    ENV_PASSWORD = 'PING_PASSWORD'
     base_url = 'https://ping-dataportal.ucsd.edu/'
 
     def __init__(self, username=None, passwd=None, verbose=1):
-        self.username = username or os.environ.get('PING_USERNAME')
-        self.passwd = passwd or os.environ.get('PING_PASSWORD')
+        self.username = username or os.environ.get(self.ENV_USERNAME)
+        self.passwd = passwd or os.environ.get(self.ENV_PASSWORD)
         self.check_login_info()
 
         self.sess = requests.Session()

--- a/regress.py
+++ b/regress.py
@@ -8,6 +8,7 @@ import csv
 import matplotlib.pyplot as plt
 import numpy as np
 
+from ping.apps import PINGSession
 from ping.apps.regress import find_one_relationship, skip_key, skip_pairing
 from ping.utils import do_and_plot_regression
 from research.asymmetry import is_ai_key

--- a/research/data/__init__.py
+++ b/research/data/__init__.py
@@ -163,17 +163,18 @@ def get_derived_data(filtered_data, tag=None, verbose=0):
     return data
 
 
-def get_all_data(all_data='ping', filter_fns=None, verbose=0):
+def get_all_data(all_data='ping', filter_fns=None, verbose=0,
+                 username=None, passwd=None):
     if inspect.isclass(all_data):
         data_klass = all_data
-        all_data = data_klass()
+        all_data = data_klass(username=username, passwd=passwd)
     elif isinstance(all_data, string_types):
         known_data = dict(ping=PINGData, destrieux=DestrieuxData)
         if all_data not in known_data:
             raise ValueError('Unknown dataset: %s' % all_data)
         else:
             data_klass = known_data[all_data]
-            all_data = data_klass()
+            all_data = data_klass(username=username, passwd=passwd)
     else:
         raise NotImplementedError()  # assume it's data.
 

--- a/similarity.py
+++ b/similarity.py
@@ -5,25 +5,27 @@ from argparse import ArgumentParser
 from collections import OrderedDict
 from functools import partial
 
+import os
 import numpy as np
 from matplotlib import pyplot as plt
 
 from ping.analysis.similarity import (compare_similarity_vectors,
                                       compute_similarity_vectors,
                                       visualize_similarity_matrices)
+from ping.apps import PINGSession
 from research.asymmetry import is_ai_key
 from research.data import get_all_data
 
 
 def do_similarity(prefix, metric='partial-correlation', measures=None,
-                  dataset='ping'):
+                  dataset='ping', username=None, passwd=None):
 
     # Get prefix
     prefix = prefix.split(',')
     prefix_filter_fn = lambda k, v: np.any([k.startswith(p) for p in prefix])
 
     # Load and filter the data
-    p_data = get_all_data(dataset)
+    p_data = get_all_data(dataset, username=username, passwd=passwd)
     p_data.filter(prefix_filter_fn)
 
     # Determine filters for selecting the similarity groupings.
@@ -97,5 +99,10 @@ if __name__ == '__main__':
                         nargs='?', default='all')
     parser.add_argument('--dataset', choices=['ping', 'destrieux'],
                         nargs='?', default='ping')
+    parser.add_argument('--username', nargs='?',
+                        default=os.environ.get(PINGSession.ENV_USERNAME))
+    parser.add_argument('--password', nargs='?',
+                        default=os.environ.get(PINGSession.ENV_PASSWORD),
+                        dest='passwd')
     args = parser.parse_args()
     do_similarity(**vars(args))

--- a/similarity.py
+++ b/similarity.py
@@ -100,9 +100,9 @@ if __name__ == '__main__':
     parser.add_argument('--dataset', choices=['ping', 'destrieux'],
                         nargs='?', default='ping')
     parser.add_argument('--username', nargs='?',
-                        default=os.environ.get(PINGSession.ENV_USERNAME))
+                        default=PINGSession.env_username())
     parser.add_argument('--password', nargs='?',
-                        default=os.environ.get(PINGSession.ENV_PASSWORD),
+                        default=PINGSession.env_passwd(),
                         dest='passwd')
     args = parser.parse_args()
     do_similarity(**vars(args))

--- a/snps.py
+++ b/snps.py
@@ -6,11 +6,11 @@ from argparse import ArgumentParser
 from ping.apps.snps import PINGSNPSession
 
 
-def do_snps(action, snp_gene):
+def do_snps(action, snp_gene, username=None, passwd=None):
     if snp_gene.startswith('rs'):
         # SNP => gene mapping
         snp = snp_gene
-        sess = PINGSNPSession()
+        sess = PINGSNPSession(username=None, passwd=None)
 
         print("Loading SNPS...")
         snp_metadata = sess.get_snp_metadata(snp)
@@ -57,5 +57,10 @@ if __name__ == '__main__':
     parser.add_argument('snp_gene', metavar="snp/gene",
                         help="case-sensitive text label; if it starts with"
                              " 'rs', it is taken to be a SNP")
+    parser.add_argument('--username', nargs='?',
+                        default=PINGSNPSession.env_username())
+    parser.add_argument('--password', nargs='?',
+                        default=PINGSNPSession.env_passwd(),
+                        dest='passwd')
     args = parser.parse_args()
     do_snps(**vars(args))

--- a/upload.py
+++ b/upload.py
@@ -2,6 +2,7 @@
 Export all measures to a spreadsheet, then
 upload to the PING server.
 """
+import os
 from functools import partial
 
 from export import EXPORTED_PING_SPREADSHEET


### PR DESCRIPTION
The only option for users to pass username/password to these scripts was as environment variables. 

In this PR, I tunnel username/password into the code via command-line arguments. Thank goodness for yesterday's migration to `argparse`!

Commands migrated: `grouping`, `gwas`, `scatter`, `similarity`, `snps`
Commands *not* migrated: `export`, `upload`
Commands still broken: `regress`

Testing: tested most of these commands manually.